### PR TITLE
Restrict model management endpoints to admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 - `GET /admin/api/config` – текущий порт и дневной лимит
 - `POST /admin/api/config` – обновить порт и лимит
 - `GET /admin/api/models` – список установленных моделей
+- `GET /admin/api/models/available` – доступные для установки модели
+- `GET /admin/api/models/{name}/variants` – варианты конкретной модели
+- `POST /admin/api/models/{name}/install` – установить модель
+- `DELETE /admin/api/models/{name}` – удалить модель
 - `GET /admin/api/sessions` – список сессий чата с количеством сообщений
 - `POST /admin/api/restart` – перезапуск сервера API
 - `GET /admin/api/status` – текущий порт API, состояние процесса и число сессий

--- a/app/api_app.py
+++ b/app/api_app.py
@@ -2,7 +2,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.database import engine, Base
-from app.routers import auth, models, chat, history, limits
+from app.routers import auth, chat, history, limits
 
 app = FastAPI(
     title="Ollama Proxy API",
@@ -24,7 +24,6 @@ app.add_middleware(
 
 # Подключаем только API-роутеры
 app.include_router(auth.router)
-app.include_router(models.router, prefix="/models", tags=["Models"])
 app.include_router(chat.router, prefix="/chat", tags=["Chat"])
 app.include_router(history.router, prefix="/history", tags=["History"])
 app.include_router(limits.router, prefix="/limits", tags=["Limits"])

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from app.database import engine, Base
-from app.routers import auth, models, chat, history, admin
+from app.routers import auth, chat, history, admin
 
 app = FastAPI(
     title="Ollama Proxy API",
@@ -29,7 +29,6 @@ app.add_middleware(
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 app.include_router(auth.router)
-app.include_router(models.router, prefix="/models", tags=["Models"])
 app.include_router(chat.router, prefix="/chat", tags=["Chat"])
 app.include_router(history.router, prefix="/history", tags=["History"])
 app.include_router(admin.router)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -21,7 +21,13 @@ from sqlalchemy.orm import Session
 
 from app.database import SessionLocal
 from app.models import User, RateLimit, Session as SessionModel, Message
-from app.utils.ollama import list_installed_models, remove_model
+from app.utils.ollama import (
+    list_installed_models,
+    remove_model,
+    list_remote_base_models,
+    list_model_variants,
+    install_model,
+)
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -323,6 +329,46 @@ def api_installed_models(admin: str = Depends(get_current_admin)):
     try:
         models = list_installed_models()
         return JSONResponse(models)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/admin/api/models/available")
+def api_available_models(admin: str = Depends(get_current_admin)):
+    """List base models available for installation."""
+    try:
+        models = list_remote_base_models()
+        return JSONResponse(models)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/admin/api/models/{name}/variants")
+def api_model_variants(name: str, admin: str = Depends(get_current_admin)):
+    """List variants for a specific model."""
+    try:
+        variants = list_model_variants(name)
+        return JSONResponse(variants)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/admin/api/models/{name}/install")
+def api_install_model(name: str, admin: str = Depends(get_current_admin)):
+    """Install a model from the registry."""
+    try:
+        install_model(name)
+        return JSONResponse({"message": f"Model '{name}' installed."})
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/admin/api/models/{name}")
+def api_remove_model(name: str, admin: str = Depends(get_current_admin)):
+    """Remove an installed model."""
+    try:
+        remove_model(name)
+        return JSONResponse({"message": f"Model '{name}' removed."})
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/app/routers/models.py
+++ b/app/routers/models.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from typing import List, Dict
 
 from app.routers.auth import get_current_username
+from app.routers.admin import get_current_admin
 from app.utils.ollama import (
     list_remote_base_models,
     list_model_variants,
@@ -20,7 +21,7 @@ from app.utils.ollama import (
 router = APIRouter()
 
 @router.get("", response_model=Dict[str, List[str]])
-async def get_models(username: str = Depends(get_current_username)) -> Dict[str, List[str]]:
+async def get_models(username: str = Depends(get_current_admin)) -> Dict[str, List[str]]:
     """Возвращает списки доступных и локально установленных моделей"""
     try:
         available = list_remote_base_models()
@@ -34,7 +35,7 @@ async def get_models(username: str = Depends(get_current_username)) -> Dict[str,
 
 
 @router.get("/available", response_model=List[str])
-async def available_models(username: str = Depends(get_current_username)) -> List[str]:
+async def available_models(username: str = Depends(get_current_admin)) -> List[str]:
     """Список моделей, доступных для установки (без вариантов)."""
     try:
         return list_remote_base_models()
@@ -58,7 +59,7 @@ async def installed_models(username: str = Depends(get_current_username)) -> Lis
 
 
 @router.get("/{name}/variants", response_model=List[str])
-async def model_variants(name: str, username: str = Depends(get_current_username)) -> List[str]:
+async def model_variants(name: str, username: str = Depends(get_current_admin)) -> List[str]:
     """Вариации указанной модели с параметрами."""
     try:
         return list_model_variants(name)
@@ -69,7 +70,7 @@ async def model_variants(name: str, username: str = Depends(get_current_username
         )
 
 @router.post("/{name}/install")
-async def install(name: str, username: str = Depends(get_current_username)) -> Dict[str, str]:
+async def install(name: str, username: str = Depends(get_current_admin)) -> Dict[str, str]:
     """Устанавливает модель по её имени из публичного реестра"""
     try:
         install_model(name)
@@ -81,7 +82,7 @@ async def install(name: str, username: str = Depends(get_current_username)) -> D
         )
 
 @router.delete("/{name}")
-async def uninstall(name: str, username: str = Depends(get_current_username)) -> Dict[str, str]:
+async def uninstall(name: str, username: str = Depends(get_current_admin)) -> Dict[str, str]:
     """Удаляет локально установленную модель"""
     try:
         remove_model(name)


### PR DESCRIPTION
## Summary
- limit model admin functions to port 8080 via admin router
- remove model routes from public API
- restrict model endpoints in `models.py` to admin auth
- document new admin endpoints for model management

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683d05016a84832faadcc11820b8e359