### PR TITLE
Add created_at column to User model

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -20,6 +20,7 @@ class User(Base):
     password_hash = Column(String, nullable=False)
     is_admin = Column(Boolean, default=False)
     daily_limit = Column(Integer, default=1000)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
 class RateLimit(Base):

--- a/app/utils/db_snapshot.py
+++ b/app/utils/db_snapshot.py
@@ -20,6 +20,7 @@ def serialize_user(user: User) -> Dict[str, object]:
         "username": user.username,
         "is_admin": user.is_admin,
         "daily_limit": user.daily_limit,
+        "created_at": user.created_at.isoformat() if user.created_at else None,
     }
 
 

--- a/cli.py
+++ b/cli.py
@@ -21,7 +21,7 @@ def main():
     """
     load_dotenv()
 
-    # 1) Миграция схемы: users → is_admin, daily_limit и новые связи
+    # 1) Миграция схемы: users → is_admin, daily_limit, created_at и новые связи
     insp = inspect(engine)
     if "users" in insp.get_table_names():
         cols = [c["name"] for c in insp.get_columns("users")]
@@ -34,6 +34,12 @@ def main():
                 conn.execute(
                     text(
                         "ALTER TABLE users ADD COLUMN daily_limit INTEGER DEFAULT 1000"
+                    )
+                )
+            if "created_at" not in cols:
+                conn.execute(
+                    text(
+                        "ALTER TABLE users ADD COLUMN created_at DATETIME DEFAULT CURRENT_TIMESTAMP"
                     )
                 )
 


### PR DESCRIPTION
## Summary
- add `created_at` column in `User` model
- expose `created_at` in database snapshots
- migrate old databases via CLI

## Testing
- `pytest -q`
- `python - <<'EOF'
from app.database import engine, Base
import app.models
Base.metadata.create_all(bind=engine)
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_683f5cb99314832f9a0bf66722e0be19