### PR TITLE
Add mobile snapshot WebSocket

### DIFF
--- a/app/api_app.py
+++ b/app/api_app.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.database import engine, Base
 from app.routers import auth, chat, history, limits
+from app.routers.mobile import router as mobile_router
 
 app = FastAPI(
     title="Ollama Proxy API",
@@ -27,3 +28,4 @@ app.include_router(auth.router)
 app.include_router(chat.router, prefix="/chat", tags=["Chat"])
 app.include_router(history.router, prefix="/history", tags=["History"])
 app.include_router(limits.router, prefix="/limits", tags=["Limits"])
+app.include_router(mobile_router, tags=["Mobile"])

--- a/app/routers/mobile.py
+++ b/app/routers/mobile.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+import asyncio
+
+from app.utils.db_snapshot import collect_detailed_snapshot
+
+router = APIRouter()
+
+
+@router.websocket("/ws/mobile")
+async def mobile_ws(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            snapshot = collect_detailed_snapshot()
+            await websocket.send_json(snapshot)
+            await asyncio.sleep(5)
+    except WebSocketDisconnect:
+        pass


### PR DESCRIPTION
## Summary
- add `/ws/mobile` WebSocket router that streams detailed snapshot
- extend database snapshot utilities with `collect_detailed_snapshot`
- register the new router in the public API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7e47fe04832f8b7497b0abbf4ae9